### PR TITLE
feat: support JSON Path in BFL

### DIFF
--- a/AnalysisScript/AnalysisScript.csproj
+++ b/AnalysisScript/AnalysisScript.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JsonPath.Net" Version="0.8.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/AnalysisScript/AnalysisScript.csproj
+++ b/AnalysisScript/AnalysisScript.csproj
@@ -7,7 +7,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/Deliay/AnalysisScript/</RepositoryUrl>
     <Description>A super mini script for data processing</Description>
-    <Version>1.0.2-beta.10</Version>
+    <Version>1.0.2</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/AnalysisScript/Interpreter/Variables/ExprTreeHelper.cs
+++ b/AnalysisScript/Interpreter/Variables/ExprTreeHelper.cs
@@ -155,6 +155,7 @@ public static class ExprTreeHelper
         var valueProperty = GetValueContainerValueGetter(type);
 
         return (ContainerParameter, valueProperty);
+        
     }
 
     public static MethodCallExpression GetConstantValueLambda<T>(T? value)


### PR DESCRIPTION
Summary
----
Add the JSON Path function to BFL.

- `filter_not_null`: filter every item in `IEnumerable<T>` or `IAsyncEnumerable<T>` keep items that are not null.
- `json_node`: convert a JSON string or `T` or `IAsyncEnumerable<T>` to `JsonNode` to support evaluating the 'JSON path' operation.
- `json_path`: Evaluate `JSON path` to `JsonNode`, `JSON string`, `T`, `IAsyncEnumerable` and return `IEnumerable<JsonNode>` for rest operations.
